### PR TITLE
cleverref needs to be after hyperref

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -19,10 +19,10 @@
 \usepackage{listings}
 \usepackage{makecell}
 \usepackage{appendix}
-\usepackage{cleveref}
 \usepackage[]{algorithm2e}
 \usepackage{titlesec}
 \usepackage[breaklinks=true,hidelinks,pdfusetitle]{hyperref}
+\usepackage{cleveref}
 \usepackage{ifthen}
 
 \makeindex


### PR DESCRIPTION
Labels and cref ends up as ?? in the thesis. I believe that cleverref needs to be after hyperref. 

https://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before