### PR TITLE
Right justify the left column in the committee membership page

### DIFF
--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -417,7 +417,7 @@ DATE SUBMITTED: \@degreemonth~\@degreeyear
 \par
 \vspace*{0.5in}
 
-\begin{tabular}{lp{3.01in}}
+\begin{tabular}{rp{3.01in}}
 TITLE:  &\@title     \par\\
 AUTHOR: &\@author     \par\\
 DATE SUBMITTED: &\@degreemonth~\@degreeyear  \par\\


### PR DESCRIPTION
When I submitted my thesis I was asked to right justify the left column on the committee membership page to match the example thesis posted online.  This one-char PR fixed the issue for everyone.  

Example: 
![image](https://user-images.githubusercontent.com/742852/42105379-fd9ccd3a-7b84-11e8-8f1f-3b086b122785.png)
