### PR TITLE
Replaced the ShareLaTeX README references with Overleaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,8 @@ Most files have examples on how they should be used inside of them. I've compile
 - [ ] Don't forget to thank your parents! Fill in ```acknowledgements.tex```.
 - [ ] Be sure to cite your sources in ```bibliography.bib```. If you use Google Scholar to find your sources, it will provide you with ```bibtex``` output under the "cite" option.
 
-# ShareLaTeX
-Want to take your thesis writing ***to the cloud?!?!*** Or, you know, don't want to install the ~3GB girthy monstrosity that is LaTeX on your pristine machine? Use [ShareLaTeX](https://www.sharelatex.com/).
-
-> I used ShareLaTeX to write my thesis and only experienced two days of downtime! I also didn't kill myself!
-
-> *-- Andrew Guenther, Cal Poly CSC Graduate*
+# Overleaf
+Want to take your thesis writing ***to the cloud?!?!*** Or, you know, don't want to install the ~3GB girthy monstrosity that is LaTeX on your pristine machine? Use [Overleaf](https://www.overleaf.com/).
 
 # Questions?
 If you have a general question about LaTeX, I would recommend you do a Google search first and check out [the TeX Stack Exchange](http://tex.stackexchange.com/). If you have a question specifically about this template and its use, feel free to submit an issue using the "question" tag.


### PR DESCRIPTION
Since ShareLaTeX is now part of Overleaf, I updated the references. I removed the quote cause I couldn't think of anything good to replace it.