### PR TITLE
Create build-and-publish.yml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,67 @@
+name: Build and Release new sample PDF
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches:
+    - master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      # Runs a set of commands using the runners shell
+      - name: Install LaTex Dependencies
+        run: |
+          sudo apt-get install -y texlive-base texlive-bibtex-extra texlive-binaries texlive-extra-utils texlive-font-utils texlive-fonts-extra texlive-fonts-recommended texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-pictures texlive-pstricks texlive-publishers texlive-science
+          sudo apt-get install -y latexmk
+          
+      - name: Build
+        run: |
+          cd ${{ github.workspace }} 
+          latexmk -pdf -interaction=nonstopmode -f main.tex
+          ls
+        
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: Sample PDF
+          path: ${{ github.workspace }}/main.pdf
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: ${{ steps.date.outputs.date }}
+          tag_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload to Release
+        id: Sample_PDF
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/main.pdf
+          asset_name: main.pdf
+          asset_content_type: application/zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: trusty
-sudo: required
-install:
-   - sudo apt-get install -y texlive-base texlive-bibtex-extra texlive-binaries texlive-extra-utils texlive-font-utils texlive-fonts-extra texlive-fonts-recommended texlive-generic-recommended texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-pictures texlive-pstricks texlive-publishers texlive-science
-   - sudo apt-get install -y latexmk
-
-script:
-   - latexmk -pdf -interaction=nonstopmode -f main.tex


### PR DESCRIPTION
This PR adds a GitHub Action that will run when a PR is completed into `master`.

This action will build the LaTeX project and publish `main.pdf` as a build artifact and create a release and upload `main.pdf` as a release asset. 
Also removes Travis-CI.yml

GitHub Action is free for public repositories. [Reference](https://github.com/features/actions)

See https://github.com/WardenGnaw/thesis-template/releases and https://github.com/WardenGnaw/thesis-template/actions/runs/1501564458.

Fixes: https://github.com/CalPolyCSC/thesis-template/issues/12