### PR TITLE
Committee membership page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,308 @@
+## Based on github's ignore list
+## https://github.com/github/gitignore/blob/main/TeX.gitignore
+
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+*.slg
+*.slo
+*.sls
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+*.ist
+
+# gnuplot
+*.gnuplot
+*.table
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.glog
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# newpax
+*.newpax
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# svg
+svg-inkscape/
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# titletoc
+*.ptc
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# TeXstudio
+*.txss2
+
+# TeXs
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib

--- a/frontmatter.tex
+++ b/frontmatter.tex
@@ -5,6 +5,13 @@
 \numberofmembers{2}
    \chair{Alexander Dekhtyar, Ph.D. \linebreak Professor of Computer Science}
    \othermemberA{Aaron Keen, Ph.D. \linebreak Professor of Computer Science}
-   \othermemberB{Franz Kurfess, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberB{Franz Kurfess 3, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberC{Franz Kurfess 4, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberD{Franz Kurfess 5, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberE{Franz Kurfess 6, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberF{Franz Kurfess 7, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberG{Franz Kurfess 8, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberH{Franz Kurfess 9, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberI{Franz Kurfess 10, Ph.D. \linebreak Professor of Computer Science}
 \field{Computer Science} \campus{San Luis Obispo}
 \copyrightyears{seven}

--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -286,11 +286,9 @@
 % number of lines and the amount of space between lines
 % on the approval page.
 \def\@numberofmembers{2}
-\def\@approvalspace{.75in}
+\def\@approvalstretch{1}
 \def\numberofmembers#1{\gdef\@numberofmembers{#1}
-\ifnum \@numberofmembers > 3
-\gdef\@approvalspace{.5in}
-\fi}
+\gdef\@approvalstretch{\ifcase\@numberofmembers \or 1 \or 1\or 1\or 1\or 0.90\or 0.70\or 0.55\or 0.45\or 0.35\or 0.25\fi}}
 
 % The name of your degree's field (e.g. Psychology, Computer Science)
 \def\field#1{\gdef\@field{#1}}
@@ -369,45 +367,6 @@
 \setcounter{footnote}{0}
 }}
 
-% APPROVALPAGE - Cal Poly (Added by Mark Barry 2/07)
-%              - NOTE: No longer used as of 11/08.  Use \committeemembershippage
-
-\def\approvalpage{
-\begin{alwayssingle}
-
-\begin{samepage}
-
-\begin{center}
-        APPROVAL PAGE
-\end{center}
-
-\par
-
-TITLE:  \@title      \par
-AUTHOR: \@author     \par
-DATE SUBMITTED: \@degreemonth~\@degreeyear
-
-\par
-
-\vspace{1in}
-
-\begin{tabular}{lcc}
-
-        \underline{\makebox[2.1in][l]{\@chair}}        & \hspace{0.5in} &  \underline{\makebox[2.1in][l]{}} \\
-        Advisor or Committee Chair \vspace{0.75in}   & & Signature \\
-        \underline{\makebox[2.1in][l]{\@othermemberA}} & &  \underline{\makebox[2.1in][l]{}} \\
-        Committee Member    \vspace{0.75in}          & & Signature \\
-        \underline{\makebox[2.1in][l]{\@othermemberB}} & &  \underline{\makebox[2.1in][l]{}} \\
-        Committee Member    \vspace{0.75in}          & & Signature \\
-
-\end{tabular}
-
-\end{samepage}
-
-\end{alwayssingle}
-}
-
-
 % COMMITTEEMEMBERSHIPPAGE - Cal Poly (Added by Andrew Tsui 6/09)
 
 \def\committeemembershippage{
@@ -419,6 +378,9 @@ DATE SUBMITTED: \@degreemonth~\@degreeyear
 \par
 \vspace*{0.5in}
 
+\begingroup
+
+\renewcommand\arraystretch{\@approvalstretch}
 \begin{tabular}{rp{3.01in}}
 TITLE:  &\@title     \par\\
 AUTHOR: &\@author     \par\\
@@ -438,6 +400,8 @@ COMMITTEE CHAIR:  &\begin{minipage}[t]{\columnwidth}\begin{flushleft}\@chair\end
 \ifnum\@numberofmembers>9 COMMITTEE MEMBER: &\begin{minipage}[t]{\columnwidth}\begin{flushleft}\@othermemberI\end{flushleft}\end{minipage}     \par\\\\ \fi
 
 \end{tabular}
+
+\endgroup
 
 \end{alwayssingle}
 }


### PR DESCRIPTION
A student using this template had a problem with the committee membership page for their committee of 5 members. The table containing the page content was too long and we pushed off to a new page. This changes the tabular spacing the ensure that all committee members (up to the current max of 10) will fit on one page.