### PR TITLE
Title Page Format

### DIFF
--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -349,30 +349,29 @@
     \setcounter{page}{1}
 
     \vfill\null
-    \vspace{-0.2in}
   \begin{center}
         \invpyramid{\MakeTextUppercase{\@title}}
 
         %\vfill\null
         \addvspace{1.4in}
 
-    A Thesis \par
-    presented to \par
-    the Faculty of California Polytechnic State University, \par
+    A Thesis \\
+    presented to \\
+    the Faculty of California Polytechnic State University, \\
     \@campus
 
         \addvspace{1.4in}
         %\vfill\null
 
 
-        In Partial Fulfillment \par
-        of the Requirements for the Degree \par
+        In Partial Fulfillment \\
+        of the Requirements for the Degree \\
         \@degree~in~\@field
 
         \addvspace{0.65in}
 
-        by \par
-        \@author \par
+        by \\
+        \@author \\
         \@degreemonth~\@degreeyear
 
 

--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -319,6 +319,26 @@
 
 
 % TITLE PAGE - Cal Poly (Added by Mark Barry 2/07)
+% Inverted pyramid title based on https://tex.stackexchange.com/a/19846
+\newcommand\invpyramid[1]{%
+        \vbox{%
+                \hsize=\textwidth
+                \parindent=0pt
+                \leftskip=0pt plus.5fil
+                \rightskip=0pt plus-0.5fil
+                \parfillskip=0pt plus1fil
+                \emergencystretch=1in
+                \parshape6
+                0.00in \textwidth
+                0.1\textwidth 0.8\textwidth
+                0.2\textwidth 0.7\textwidth
+                0.3\textwidth 0.6\textwidth
+                0.35\textwidth 0.55\textwidth
+                0.4\textwidth 0.5\textwidth
+                \strut
+                #1%
+        }%
+}
 
 \def\maketitle{
 {
@@ -331,9 +351,7 @@
     \vfill\null
     \vspace{-0.2in}
   \begin{center}
-        \MakeTextUppercase{\@title}
-    % or another variation would be:
-    % \textsc{\@title}
+        \invpyramid{\MakeTextUppercase{\@title}}
 
         %\vfill\null
         \addvspace{1.4in}


### PR DESCRIPTION
Fixed multiple problems with the title page. First, the spacing was not consistent between lines in a multi-line title and the other text on the title page. Second, the current format requires multi-line titles on the title to be formatted in an "inverted pyramid" style. [This file](https://github.com/CalPolyCSC/thesis-template/files/15341931/main-title-page-errors.pdf) shows both problems, and [this file](https://github.com/CalPolyCSC/thesis-template/files/15341934/main-title-page-fixed.pdf) shows the corrected result. This fixes #36, and probably #27 as well (currently multi-line titles do not push bottom title page contents to next page).

