### PR TITLE
Dedication Page

### DIFF
--- a/acknowledgements.tex
+++ b/acknowledgements.tex
@@ -1,4 +1,5 @@
-\noindent
+This page is optional, but if you have received funding for your research or assistance or guidance that you feel should be noted, it belongs on this page. If you are not including acknowledgments, delete this page. If you are acknowledging only one person, change the title to ACKNOWLEDGMENT.
+
 Thanks to:
 \begin{itemize}
     \item Andrew Guenther, for uploading this template

--- a/dedication.tex
+++ b/dedication.tex
@@ -1,0 +1,1 @@
+This is optional, but can be included if desired.

--- a/main.tex
+++ b/main.tex
@@ -128,6 +128,9 @@
 \input{acknowledgements}
 \end{acknowledgements}
 
+\begin{dedication}
+\input{dedication}
+\end{dedication}
 \tableofcontents
 
 \listoftables

--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -235,6 +235,9 @@
 % vitae environment:
 \def\vitaename{Curriculum Vit\ae}
 %              ~~~~~~~~~~~~~~~~
+%
+\def\dedicationname{Dedication}
+%
 
 %    ****************************************
 %    *             FRONT MATTER             *
@@ -471,7 +474,11 @@ Thesis Committee Chair
 % The dedication environment just makes sure the dedication gets its
 % own page.
 
-\newenvironment{dedication}{\begin{alwayssingle}}{\end{alwayssingle}}
+\newenvironment{dedication}{\begin{alwayssingle}
+\begin{center}
+{\large \MakeTextUppercase{\dedicationname}}
+\end{center}
+}{\end{alwayssingle}}
 
 % ACKNOWLEDGEMENTS
 %


### PR DESCRIPTION
Added ability to include a dedication in the front matter after the acknowledgments. [This file](https://github.com/CalPolyCSC/thesis-template/files/15342328/main-dedication-missing.pdf) shows the original front matter, and [this file](https://github.com/CalPolyCSC/thesis-template/files/15342330/main-dedication-fixed.pdf) shows the the inclusion of a dedication page. Fixes #28.
