### PR TITLE
Figure Table Fixes

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,8 @@
 \documentclass[12pt]{ucthesis}
 
+\usepackage{floatrow}
+% from https://tex.stackexchange.com/a/43097
+\floatsetup[table]{capposition=top}
 \usepackage{etex}
 \usepackage[morefloats=125]{morefloats}
 \usepackage[hyphens]{url}

--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -853,28 +853,35 @@ Thesis Committee Chair
 % redefine chapter command to remove the extra vertical space between
 % chapters in list of figures and list of tables
 % see: https://tex.stackexchange.com/a/69327
+%
+% make toc entry uppercase
+% see: https://tex.stackexchange.com/a/109948
+\renewcommand\chapter{\if@openright\cleardoublepage\else\clearpage\fi
+                    \thispagestyle{plain}%
+                    \global\@topnum\z@
+                    \@afterindentfalse
+                    \secdef\@chapter\@schapter}
 \def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
                        \if@mainmatter
                          \refstepcounter{chapter}%
                          \typeout{\@chapapp\space\thechapter.}%
                          \addcontentsline{toc}{chapter}%
-                                   {\protect\numberline{\thechapter}#1}%
+                                   {\protect\numberline{\thechapter}\uppercase{#1}}%
                        \else
-                         \addcontentsline{toc}{chapter}{#1}%
+                         \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
                        \fi
                     \else
-                      \addcontentsline{toc}{chapter}{#1}%
+                      \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
                     \fi
                     \chaptermark{#1}%
-%                    \addtocontents{lof}{\protect\addvspace{10\p@}}% NEW
-%                    \addtocontents{lot}{\protect\addvspace{10\p@}}% NEW
+%                    \addtocontents{lof}{\protect\addvspace{10\p@}}%
+%                    \addtocontents{lot}{\protect\addvspace{10\p@}}%
                     \if@twocolumn
                       \@topnewpage[\@makechapterhead{#2}]%
                     \else
                       \@makechapterhead{#2}%
                       \@afterheading
                     \fi}
-
 
 
 

--- a/ucthesis.cls
+++ b/ucthesis.cls
@@ -846,6 +846,35 @@ Thesis Committee Chair
    #1\par}\@endpart}
 
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                       CHAPTER                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% redefine chapter command to remove the extra vertical space between
+% chapters in list of figures and list of tables
+% see: https://tex.stackexchange.com/a/69327
+\def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
+                       \if@mainmatter
+                         \refstepcounter{chapter}%
+                         \typeout{\@chapapp\space\thechapter.}%
+                         \addcontentsline{toc}{chapter}%
+                                   {\protect\numberline{\thechapter}#1}%
+                       \else
+                         \addcontentsline{toc}{chapter}{#1}%
+                       \fi
+                    \else
+                      \addcontentsline{toc}{chapter}{#1}%
+                    \fi
+                    \chaptermark{#1}%
+%                    \addtocontents{lof}{\protect\addvspace{10\p@}}% NEW
+%                    \addtocontents{lot}{\protect\addvspace{10\p@}}% NEW
+                    \if@twocolumn
+                      \@topnewpage[\@makechapterhead{#2}]%
+                    \else
+                      \@makechapterhead{#2}%
+                      \@afterheading
+                    \fi}
+
 
 
 


### PR DESCRIPTION
Fixes formatting associated with figures and tables.

- Forces chapter titles to be uppercase in table of contents (first page, page iv).
- Removed vertical space in list of tables and list of figures at the start of each chapter (second and third page, pages vii an viii). Note slight spacing between List of Tables entries 1.2 and 2.1 as well as List of Figures entries 1.3 and 2.1. Fixes #24.
- Now table captions are forced to be above the table (fourth page, page 2).  Fixes #30.

[This file](https://github.com/CalPolyCSC/thesis-template/files/15382695/main-figure-table-error.pdf) shows the problems and [this file](https://github.com/CalPolyCSC/thesis-template/files/15382704/main-figure-table-fixed.pdf) shows the corrections.

