### PR TITLE
Appendix Start Label

### DIFF
--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -815,6 +815,10 @@ ALL RIGHTS RESERVED
                       \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
                     \fi
                     \chaptermark{#1}%
+                      % This adds APPENDICES to header of first appendix only
+                      \ifnum\value{chapter}<2
+                          {\centering\MakeUppercase{\appendicestocname} \\} \vspace{\baselineskip}
+                      \fi
                       \@makechapterhead{#2}%
                       \@afterheading
                     }


### PR DESCRIPTION
The top of the first appendix page needs to indicate that this is is the start of the appendices. It needs to have either APPENDIX if there is only one appendix, or APPENDICES of there are more than one appendices.