### PR TITLE
Remove list of symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The ```preamble.tex``` file should be used to put all of the LaTeX configuration
 The current file includes the ```lipsum``` package for the placeholder text used in the example thesis.
 This package should be removed in your thesis.
 This file also contains an example of the package and libraries that might be needed for using [TikZ](https://tikz.dev/).
-Finally, this file also contains an example of how to perform grouping in your nomenclature (List of Symbols) using the ```nomencl``` package.
+Finally, this file also contains an example of how to perform grouping in your nomenclature (list of symbols) using the ```nomencl``` package.
 Your thesis advisor might have a preferred way of organizing your nomenclature, so this code will need to be changed to suit your needs.
 
 The ```abstract.tex``` file should contain the text associated with your abstract.
@@ -43,16 +43,6 @@ Work with your advisor on whether this applies to your work.
 Note that if you only have one acknowledgment then this page must be titled is the singular.
 In that case uncomment the line redefining the ```\acknowledgename``` macro on line 2.
 If you have no acknowledgments, then this file can be blank.
-
-The ```nomenclature.tex``` file provides a convenient location for all of your symbols and terms to be declared with the ```\nomenclature``` command.
-These will appear in the List of Symbols section of your thesis.
-If you have a preferred way of assembling your nomenclature, then you do not have to have your nomenclature in this file.
-The nomenclature command in ```listings.tex``` is what puts the list of symbols into the thesis in the correct place.
-If you are not going to have a List of Symbols in your thesis, then the ```nomenclature.tex``` file can be blank.
-
-If you plan on creating a List of Symbols, then you should look at the documentation of the ```nomencl``` package as well as examples that are on the internet.
-As quick summary, the ```\nomenclature[arg1]{arg2}{arg3}``` command will create a new entry for ```arg2``` in the List of Symbols with the description of ```arg3```.
-The optional ```arg1``` is used in the sorting and grouping of entries, where code in ```preamble.tex``` defines the grouping in this example.
 
 The ```listings.tex``` file contains the commands needed to get the approved lists that might need to be in your thesis.
 If any of these lists are empty in your thesis, then you need to remove the associated commands from this file.
@@ -80,6 +70,18 @@ There are some formatting changes that have to happen in your thesis associated 
 Because some of these formatting changes depend on the number of appendices, this command takes an optional argument indicating the number of appendices, for example with 3 appendices you could use ```\appendix[3]``` or ```\appendix```.
 If you only have one appendix, then you **must** use the optional optional like this: ```\appendix[1]```.
 The rest of this directory follows the same logic as the ```chapters``` directory discussed above.
+
+#### Nomenclature as an Appendix
+If your thesis is going to have a nomenclature (or list of symbols), then it has to be in the appendix of your thesis.
+The ```nomenclature.tex``` file provides a convenient location for all of your symbols and terms to be declared with the ```\nomenclature``` command.
+These will appear as an appendix in your thesis.
+If you (or your thesis advisor) have a preferred way of assembling your nomenclature, then you do not have to have your nomenclature in this file.
+If you are not going to have a nomenclature in your thesis, then the ```nomenclature.tex``` file can be blank.
+
+If you plan on creating a nomenclature, then you should look at the documentation of the ```nomencl``` package as well as examples that are on the internet.
+As quick summary, the ```\nomenclature[arg1]{arg2}{arg3}``` command will create a new entry for ```arg2``` in the nomenclature with the description of ```arg3```.
+The optional ```arg1``` is used in the sorting and grouping of entries, where code in ```preamble.tex``` defines the grouping in this example.
+
 
 ### Figures Content
 Most theses contain a large number of figures, so it is convenient to collect all of those figures into a common directory.
@@ -132,7 +134,7 @@ Most files have examples on how they should be used inside of them. Here is a ha
 - [ ] Got some appendices? You're covered, same idea as with chapters, but using ```appendices/outline.tex``` and the ```appendices``` folder instead.
 - [ ] Write your abstract in ```abstract.tex```. That's it. The template takes care of all the formatting for you.
 - [ ] Don't forget to thank your family! Fill in ```acknowledgments.tex```.
-- [ ] Make sure your family knows what you are talking about. Create a List of Symbols using the ```nomenclature.tex``` file. Or don't have one and let them figure it out on their own. In that case be sure to remove the nomenclature code in ```listings.tex```.
+- [ ] Make sure your family knows what you are talking about. Create a nomenclature using the ```nomenclature.tex``` file. Or don't have one and let them figure it out on their own. In that case be sure to remove the nomenclature content ```appendices/nomenclature.tex``` and ```frontmatter/preamble.tex```.
 - [ ] Be sure to cite your sources in ```bibliography.bib```. If you use Google Scholar to find your sources, it will provide you with ```bibtex``` output under the "cite" option.
 - [ ] Final cleanup; you're almost there. Remove unnecessary content, such as empty listings, etc., and any placeholder text.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ Note that if you only have one acknowledgment then this page must be titled is t
 In that case uncomment the line redefining the ```\acknowledgename``` macro on line 2.
 If you have no acknowledgments, then this file can be blank.
 
-The ```dedication.tex``` file should contain a dedication.
-If you do not have a dedication, then this file can be blank.
-
 The ```nomenclature.tex``` file provides a convenient location for all of your symbols and terms to be declared with the ```\nomenclature``` command.
 These will appear in the List of Symbols section of your thesis.
 If you have a preferred way of assembling your nomenclature, then you do not have to have your nomenclature in this file.
@@ -137,7 +134,7 @@ Most files have examples on how they should be used inside of them. Here is a ha
 - [ ] Don't forget to thank your family! Fill in ```acknowledgments.tex```.
 - [ ] Make sure your family knows what you are talking about. Create a List of Symbols using the ```nomenclature.tex``` file. Or don't have one and let them figure it out on their own. In that case be sure to remove the nomenclature code in ```listings.tex```.
 - [ ] Be sure to cite your sources in ```bibliography.bib```. If you use Google Scholar to find your sources, it will provide you with ```bibtex``` output under the "cite" option.
-- [ ] Final cleanup; you're almost there. Remove unnecessary content, such as empty listings, dedication, etc., and any placeholder text.
+- [ ] Final cleanup; you're almost there. Remove unnecessary content, such as empty listings, etc., and any placeholder text.
 
 # Overleaf
 Want to take your thesis writing ***to the cloud?!?!*** Or, you know, don't want to install the ~3GB girthy monstrosity that is LaTeX on your pristine machine? Use [Overleaf](https://www.overleaf.com/). Even better, use [this template](https://www.overleaf.com/latex/templates/cal-poly-thesis-template/vvqzkxgchkvc) on Overleaf.

--- a/appendices/nomenclature.tex
+++ b/appendices/nomenclature.tex
@@ -1,3 +1,11 @@
+% If you want to have a nomenclature, it needs to be put into an appendix. If you do not
+% want one then just delete the contents of this file.
+
+\chapter{Nomenclature}\label{sec:Nomenclature}
+
+\printnomenclature
+
+
 % Adapted from Overleaf documentation
 % https://www.overleaf.com/learn/latex/Nomenclatures
 \nomenclature[P]{$c$}{Speed of light in a vacuum}

--- a/appendices/outline.tex
+++ b/appendices/outline.tex
@@ -5,6 +5,8 @@
 % to the appendix command as an optional parameter or omit it:
 \appendix
 
+\input{appendices/nomenclature}
+
 \input{appendices/appendix01}
 
 \input{appendices/appendix02}

--- a/chapters/chapter01.tex
+++ b/chapters/chapter01.tex
@@ -329,16 +329,19 @@
     There should be no reason to ever manually cross-reference an item in this document.
 
 \section{Nomenclature Usage} \label{sec:NomenclatureUsage}
-    The \nameref{sec:Nomenclature} in the preamble on \cpageref{sec:Nomenclature} shows the nomenclature for this document.
+% TODO: Rewrite this to refer to new nomenclature content
+    The \nameref{sec:Nomenclature} in the appendices on \cpageref{sec:Nomenclature} shows the nomenclature for this document.
+    A nomenclature (or list of symbols) has to be in an appendix if there is one.
     This uses the nomencl package, and you should consult the documentation for that package to see how it can be customized.
     The simplest way to implement the nomenclature/list of symbols information is how this document has created the nomenclature.
-    All of the nomenclature information is contained within the nomenclature.tex file in the frontmatter directory.
-    If no nomenclature is desired, then simply remove all of the content in this file and remove the list of symbols code in the listings.tex file.
+    All of the nomenclature information is contained within the nomenclature.tex file in the appendices directory.
 
     There are ways to sort/organize the nomenclature.
     A simple grouping is done with the code in the preamble.tex file.
     If a different sorting/grouping is desired, then this code needs to be changed.
     If no grouping or sorting is desired, then this code can be removed.
+
+    If no nomenclature is desired, then simply remove all of the content in the nomenclature.tex file and the associated nomenclature content in the preamble.tex file.
 
 \section{Citations} \label{sec:Citations}
     This document uses biblatex and the biber bibliography parser to generate the bibliography/references section.

--- a/chapters/chapter01.tex
+++ b/chapters/chapter01.tex
@@ -329,7 +329,6 @@
     There should be no reason to ever manually cross-reference an item in this document.
 
 \section{Nomenclature Usage} \label{sec:NomenclatureUsage}
-% TODO: Rewrite this to refer to new nomenclature content
     The \nameref{sec:Nomenclature} in the appendices on \cpageref{sec:Nomenclature} shows the nomenclature for this document.
     A nomenclature (or list of symbols) has to be in an appendix if there is one.
     This uses the nomencl package, and you should consult the documentation for that package to see how it can be customized.

--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -1389,4 +1389,26 @@ rmargin=1in
 \setcounter{secnumdepth}{3}
 \setcounter{tocdepth}{3}
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Nomenclature packages
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage{nomencl}
+\def\thenomenclature{%
+  \providecommand*{\listofnlsname}{\nomname}%
+  \nompreamble
+  \if@nomentbl
+    \let\itemOrig=\item
+    \def\item{\gdef\item{\\}}%
+    \expandafter\longtable\expandafter{\@nomtableformat}
+  \else
+    \list{}{%
+      \labelwidth\nom@tempdim
+      \leftmargin\labelwidth
+      \advance\leftmargin\labelsep
+      \itemsep\nomitemsep
+      \let\makelabel\nomlabel}%
+  \fi
+}
+
 \endinput

--- a/frontmatter/listings.tex
+++ b/frontmatter/listings.tex
@@ -5,6 +5,3 @@
 
 % Insert list of figures
 \printlistoffigures
-
-% Insert list of symbols
-\printnomenclature

--- a/frontmatter/preamble.tex
+++ b/frontmatter/preamble.tex
@@ -13,6 +13,7 @@
 %% This code creates groups in the nomenclature
 % based on Overleaf documentation
 % https://www.overleaf.com/learn/latex/Nomenclatures
+\makenomenclature
 \usepackage{etoolbox}
 \renewcommand\nomgroup[1]{%
     \item[\bfseries

--- a/main.tex
+++ b/main.tex
@@ -65,22 +65,6 @@
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Nomenclature packages
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\usepackage[intoc,notocbasic]{nomencl}
-% changes to formatting of the list of symbols to be upper case
-\renewcommand{\nomname}{\MakeUppercase{\listsymbolsname}}
-% allow cross-references to the nomenclature
-% see: https://tex.stackexchange.com/a/158934
-\usepackage{etoolbox}
-\patchcmd{\thenomenclature}
-  {\chapter*{\nomname}}
-  {\phantomsection\chapter*{\nomname}\label{sec:Nomenclature}}
-  {}
-  {}
-\makenomenclature
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bibliography packages
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[
@@ -192,10 +176,6 @@
 
         % Insert all of the potentially optional listings
         \input{frontmatter/listings}
-
-        % Insert list of symbols
-        % Note: package handles inserting into table of contents
-        \input{frontmatter/nomenclature.tex}
     \end{frontmatter}
 
     %% Input the chapters as configured from the file


### PR DESCRIPTION
Grad. Ed. indicated that the only front matter sections are list of tables and list of figures. List of symbols needs to be put into an appendix if it is included in a thesis.