### PR TITLE
Force biblatex to not put page break in an bibliography entry.

### DIFF
--- a/bibliography/references.bib
+++ b/bibliography/references.bib
@@ -85,6 +85,18 @@
     note      = {AIAA 1986-1786},
 }
 
+% This reference is here to force page break before long reference.
+@article{Kotz2025,
+    title     = {This paper has a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long name},
+    author    = {Kotz, P.},
+    year      = {2025},
+    journal   = {Long Names},
+    volume    = {2000},
+    pages     = {111-128},
+    publisher = {Long Name},
+    language  = {english},
+}
+
 @article{Koutsovasilis2008,
     title     = {Comparison of model reduction techniques for large mechanical systems},
     author    = {Koutsovasilis, P. and Beitelschmidt, M.},

--- a/main.tex
+++ b/main.tex
@@ -75,6 +75,9 @@
     maxnames=4,
     minnames=3,
 ]{biblatex} % bibliography
+% Ensures no page break within one entry
+% https://tex.stackexchange.com/a/43275
+\patchcmd{\bibsetup}{\interlinepenalty=5000}{\interlinepenalty=10000}{}{}
 %\AtEveryBibitem{\clearlist{language}}
 %\AtEveryBibitem{\clearfield{note}}
 \addbibresource{bibliography/references.bib}


### PR DESCRIPTION
Bibliography cannot have a page break that splits one entry onto two pages. This fixes #66.