### PR TITLE
Fixing Appendices

### DIFF
--- a/appendices/outline.tex
+++ b/appendices/outline.tex
@@ -3,7 +3,7 @@
 %\appendix[1]
 % If have multiple appendices can pass the number of appendices
 % to the appendix command as an optional parameter or omit it:
-\appendix
+\appendix[4]
 
 \input{appendices/nomenclature}
 

--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -752,6 +752,8 @@ ALL RIGHTS RESERVED
 % replace the appendix macro with custom
 \newif\if@appendix
 \@appendixfalse
+\newif\if@oneappendix
+\@oneappendixfalse
 \renewcommand\appendix[1][2]{%
     \def\@chapapp{\appendixname}
     \renewcommand\thechapter{\Alph{chapter}}
@@ -766,7 +768,14 @@ ALL RIGHTS RESERVED
         \addtocontents{toc}{\let\protect\l@subsection\protect\l@subsubsection}
         \addtocontents{toc}{\let\protect\l@subsubsection\protect\l@paragraph}
     \else
-        \addtocontents{toc}{\noindent\MakeUppercase{\appendixtocname}}
+        \@oneappendixtrue
+        % Custom format for the one appendix
+        % See: https://tex.stackexchange.com/a/110854
+        \titleformat{\chapter}
+          {\centering} % format
+          {}                % label
+          {0pt}             % sep
+          {}           % before-code
     \fi
     % Set flag to true
     \@appendixtrue
@@ -792,7 +801,11 @@ ALL RIGHTS RESERVED
                         \refstepcounter{chapter}%
                         \typeout{\@chapapp\space\thechapter.}%
                         \if@appendix
-                          \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter.}{#1}}
+                          \if@oneappendix
+                            \addcontentsline{toc}{chapter}{APPENDIX}
+                          \else
+                            \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter.}{#1}}
+                          \fi
                         \else
                           \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter.}\uppercase{#1}}
                         \fi
@@ -803,8 +816,18 @@ ALL RIGHTS RESERVED
                       \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
                     \fi
                     \chaptermark{#1}%
-                    \@makechapterhead{#2}%
-                    \@afterheading
+                    \if@appendix
+                      \if@oneappendix
+                        \@makechapterhead{APPENDIX. #1}
+                        \@afterheading
+                      \else
+                        \@makechapterhead{#2}%
+                        \@afterheading
+                      \fi
+                    \else
+                      \@makechapterhead{#2}%
+                      \@afterheading
+                    \fi
                    }
 
 

--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -783,35 +783,29 @@ ALL RIGHTS RESERVED
 % make toc entry uppercase
 % see: https://tex.stackexchange.com/a/109948
 \renewcommand\chapter{\if@openright\cleardoublepage\else\clearpage\fi
-                    \thispagestyle{plain}%
-                    \global\@topnum\z@
-                    \@afterindentfalse
-                    \secdef\@chapter\@schapter}
+                      \thispagestyle{plain}%
+                      \global\@topnum\z@
+                      \@afterindentfalse
+                      \secdef\@chapter\@schapter}
 \def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
-                       \if@mainmatter
-                         \refstepcounter{chapter}%
-                         \typeout{\@chapapp\space\thechapter.}%
-                         \if@appendix
-                             \addcontentsline{toc}{chapter}%
-                                    {\protect\numberline{\thechapter.}{#1}}
-                         \else
-                             \addcontentsline{toc}{chapter}%
-                                    {\protect\numberline{\thechapter.}\uppercase{#1}}
-                         \fi
-                       \else
-                         \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
-                       \fi
+                      \if@mainmatter
+                        \refstepcounter{chapter}%
+                        \typeout{\@chapapp\space\thechapter.}%
+                        \if@appendix
+                          \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter.}{#1}}
+                        \else
+                          \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter.}\uppercase{#1}}
+                        \fi
+                      \else
+                        \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
+                      \fi
                     \else
                       \addcontentsline{toc}{chapter}{\MakeUppercase{#1}}%
                     \fi
                     \chaptermark{#1}%
-                      % This adds APPENDICES to header of first appendix only
-                      \ifnum\value{chapter}<2
-                          {\centering\MakeUppercase{\appendicestocname} \\} \vspace{\baselineskip}
-                      \fi
-                      \@makechapterhead{#2}%
-                      \@afterheading
-                    }
+                    \@makechapterhead{#2}%
+                    \@afterheading
+                   }
 
 
 

--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -757,17 +757,17 @@ ALL RIGHTS RESERVED
     \renewcommand\thechapter{\Alph{chapter}}
     \setcounter{chapter}{0}
     \ifnum#1>1
-        {\addtocontents{toc}{\noindent\MakeUppercase{\appendicestocname}}}
+        \addtocontents{toc}{\noindent\MakeUppercase{\appendicestocname}}
+        % Indent all entries in appendix and still show sub-subsections
+        \addtocontents{toc}{\protect\setcounter{tocdepth}{4}}%
+        \setcounter{tocdepth}{4}
+        \addtocontents{toc}{\let\protect\l@chapter\protect\l@section}
+        \addtocontents{toc}{\let\protect\l@section\protect\l@subsection}
+        \addtocontents{toc}{\let\protect\l@subsection\protect\l@subsubsection}
+        \addtocontents{toc}{\let\protect\l@subsubsection\protect\l@paragraph}
     \else
-        {\addtocontents{toc}{\noindent\MakeUppercase{\appendixtocname}}}
+        \addtocontents{toc}{\noindent\MakeUppercase{\appendixtocname}}
     \fi
-    % Indent all entries in appendix and still show sub-subsections
-    \addtocontents{toc}{\protect\setcounter{tocdepth}{4}}%
-    \setcounter{tocdepth}{4}
-    \addtocontents{toc}{\let\protect\l@chapter\protect\l@section}
-    \addtocontents{toc}{\let\protect\l@section\protect\l@subsection}
-    \addtocontents{toc}{\let\protect\l@subsection\protect\l@subsubsection}
-    \addtocontents{toc}{\let\protect\l@subsubsection\protect\l@paragraph}
     % Set flag to true
     \@appendixtrue
 }
@@ -806,7 +806,6 @@ ALL RIGHTS RESERVED
                     \@makechapterhead{#2}%
                     \@afterheading
                    }
-
 
 
 %    ****************************************

--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -754,7 +754,6 @@ ALL RIGHTS RESERVED
 \@appendixfalse
 \renewcommand\appendix[1][2]{%
     \def\@chapapp{\appendixname}
-    \addtocontents{toc}{\let\protect\l@chapter\protect\l@section}
     \renewcommand\thechapter{\Alph{chapter}}
     \setcounter{chapter}{0}
     \ifnum#1>1
@@ -762,8 +761,14 @@ ALL RIGHTS RESERVED
     \else
         {\addtocontents{toc}{\noindent\MakeUppercase{\appendixtocname}}}
     \fi
-    % Indents Appendix in Table of Contents
+    % Indent all entries in appendix and still show sub-subsections
+    \addtocontents{toc}{\protect\setcounter{tocdepth}{4}}%
+    \setcounter{tocdepth}{4}
     \addtocontents{toc}{\let\protect\l@chapter\protect\l@section}
+    \addtocontents{toc}{\let\protect\l@section\protect\l@subsection}
+    \addtocontents{toc}{\let\protect\l@subsection\protect\l@subsubsection}
+    \addtocontents{toc}{\let\protect\l@subsubsection\protect\l@paragraph}
+    % Set flag to true
     \@appendixtrue
 }
 


### PR DESCRIPTION
There were a few issues with appendices that have been addressed.

- All content of table of contents for appendices needs to be indented. Fixes #69 
- Previous change added Appendices title to top of first chapter as well. Fixes #61
- Special formatting required when only have one appendix. Fixes #57 
