### PR TITLE
Front Matter Cleanup

### DIFF
--- a/frontmatter/preamble.tex
+++ b/frontmatter/preamble.tex
@@ -20,7 +20,7 @@
 \makenomenclature
 \usepackage{etoolbox}
 \renewcommand\nomgroup[1]{%
-    \item[\bfseries
+    \item[%
         \ifstrequal{#1}{P}{Physics constants}{%
         \ifstrequal{#1}{N}{Number sets}{%
         \ifstrequal{#1}{O}{Other symbols}{}}}%

--- a/frontmatter/preamble.tex
+++ b/frontmatter/preamble.tex
@@ -21,8 +21,8 @@
 \usepackage{etoolbox}
 \renewcommand\nomgroup[1]{%
     \item[%
-        \ifstrequal{#1}{P}{Physics constants}{%
-        \ifstrequal{#1}{N}{Number sets}{%
-        \ifstrequal{#1}{O}{Other symbols}{}}}%
+        \ifstrequal{#1}{P}{Physics Constants}{%
+        \ifstrequal{#1}{N}{Number Sets}{%
+        \ifstrequal{#1}{O}{Other Symbols}{}}}%
     ]\bigskip
 }

--- a/frontmatter/preamble.tex
+++ b/frontmatter/preamble.tex
@@ -24,5 +24,5 @@
         \ifstrequal{#1}{P}{Physics constants}{%
         \ifstrequal{#1}{N}{Number sets}{%
         \ifstrequal{#1}{O}{Other symbols}{}}}%
-    ]
+    ]\bigskip
 }


### PR DESCRIPTION
Removed bolding from list of symbols and added more padding for nomenclature groups. Fixes #70 and #72. Note that #70 is an artifact of the list environment that might require future changes.